### PR TITLE
Simplify installing dependencies for RLG environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ cd gym
 pip install -e .
 ``` 
 
+To install dependencies needed for Robot Locomotion Group enviroments you can run one of the following:
+```
+pip install -e .["pymunk"]
+pip install -e .["drake"]
+pip install -e .["rlg"]  # installs dependencies from all above groups
+```
+Note: If using a Drake environement, you will need to provide your own version of Drake.
+
 If you are working on this repo then add the following lines:
 ```
 cd gym 
@@ -35,13 +43,9 @@ git remote set-url --push upstream no_push
 # Workflow 
 
 You can create your own environment on a local branch or your own fork, then PR to this repo once the environment is good enough.
-Make sure you **dont't** PR to `openai/gym`, but to `RobotLocomotion/gym`! 
+Make sure you **don't** PR to `openai/gym`, but to `RobotLocomotion/gym`!
 
 # How to Add a New Environment
 
 To isolate our environments from OpenAI's original environments, let's keep the group environments in `gym/envs/robot_locomotion_group`. You will find detailed instructions in this [folder](https://github.com/RobotLocomotion/gym/tree/master/gym/envs/robot_locomotion_group).
 
-# Dependencies 
-- `pyglet`
-- `pymunk`
-- `drake`

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,16 @@ extras = {
   'atari': ['atari_py~=0.2.0', 'opencv-python>=3.'],
   'box2d': ['box2d-py~=2.3.5'],
   'classic_control': [],
+  'drake': ['meshcat', 'tinydb', 'yaml'],
   'mujoco': ['mujoco_py>=1.50, <2.0', 'imageio'],
+  'pymunk': ['pymunk', 'opencv-python'],
   'robotics': ['mujoco_py>=1.50, <2.0', 'imageio'],
 }
 
 # Meta dependency groups.
 extras['nomujoco'] = list(set([item for name, group in extras.items() if name != 'mujoco' and name != "robotics" for item in group]))
 extras['all'] = list(set([item for group in extras.values() for item in group]))
+extras['rlg'] = list(set([item for group in [extras['drake'], extras['pymunk']] for item in group]))
 
 setup(name='gym',
       version=VERSION,


### PR DESCRIPTION
Adds a pip install for dependencies of pymunk and drake environments.  Still requires users to provide their own Drake version.